### PR TITLE
feat: more verbose debug variable values

### DIFF
--- a/variables.go
+++ b/variables.go
@@ -218,6 +218,7 @@ func (p *valuePrinter) print(rv reflect.Value) {
 	case rPtr:
 		if rv.IsNil() {
 			fmt.Fprint(p, "nil")
+			return
 		}
 		fmt.Fprintf(p, "*")
 		p.print(rv.Elem())

--- a/variables.go
+++ b/variables.go
@@ -1,6 +1,7 @@
 package dbg
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -92,22 +93,9 @@ func (a *Adapter) newVar(name string, rv reflect.Value) *dap.Variable {
 		return v
 	}
 
-	switch rv.Kind() {
-	case rChan, rFunc, rInterface, rMap, rPtr, rSlice, rArray, rStruct:
-		v.Value = rv.Type().String()
-	case rInt, rInt8, rInt16, rInt32, rInt64:
-		v.Value = strconv.FormatInt(rv.Int(), 10)
-	case rUint8, rUint16, rUint, rUint32, rUint64, rUintptr:
-		v.Value = fmt.Sprintf("%v", rv)
-	case rBool:
-		v.Value = strconv.FormatBool(rv.Bool())
-	case rFloat32, rFloat64, rComplex128, rComplex64:
-		v.Value = fmt.Sprintf("%v", rv)
-	case rString:
-		v.Value = fmt.Sprintf("%q", rv.String())
-	default:
-		v.Value = fmt.Sprintf("%[1]v (%[1]T)", rv)
-	}
+	vp := newValuePrinter(128)
+	vp.print(rv)
+	v.Value = vp.String()
 
 	switch rv.Kind() {
 	case rInterface, rPtr:
@@ -194,4 +182,67 @@ func (v *mapVars) Variables(a *Adapter) []*dap.Variable {
 		vars[i] = a.newVar(k.String(), v.MapIndex(k))
 	}
 	return vars
+}
+
+type valuePrinter struct {
+	maxLength int
+	size      int
+	buffer    *bytes.Buffer
+}
+
+func newValuePrinter(max int) *valuePrinter {
+	return &valuePrinter{maxLength: max, buffer: new(bytes.Buffer)}
+}
+
+func (p *valuePrinter) print(rv reflect.Value) {
+	switch rv.Kind() {
+	case rChan, rFunc, rInterface, rMap, rPtr, rArray, rStruct:
+		fmt.Fprint(p, rv.Type().String())
+	case rInt, rInt8, rInt16, rInt32, rInt64:
+		fmt.Fprint(p, strconv.FormatInt(rv.Int(), 10))
+	case rUint8, rUint16, rUint, rUint32, rUint64, rUintptr:
+		fmt.Fprint(p, fmt.Sprintf("%v", rv))
+	case rBool:
+		fmt.Fprint(p, strconv.FormatBool(rv.Bool()))
+	case rFloat32, rFloat64, rComplex128, rComplex64:
+		fmt.Fprint(p, fmt.Sprintf("%v", rv))
+	case rString:
+		fmt.Fprint(p, fmt.Sprintf("%q", rv.String()))
+	case rSlice:
+		fmt.Fprint(p, rv.Type().String())
+		fmt.Fprint(p, "{")
+		for i := 0; i < rv.Len(); i++ {
+			if i > 0 {
+				fmt.Fprint(p, ",")
+			}
+			p.print(rv.Index(i))
+		}
+		fmt.Fprint(p, "}")
+	default:
+		fmt.Fprintf(p, "%[1]T %[1]v", rv)
+	}
+}
+
+func (p *valuePrinter) full() bool {
+	return p.maxLength-p.buffer.Len() == 0
+}
+
+func (p *valuePrinter) String() string {
+	if p.full() {
+		p.buffer.WriteString("...")
+	}
+	return p.buffer.String()
+}
+
+func (p *valuePrinter) Write(b []byte) (n int, err error) {
+	rem := p.maxLength - p.size
+	if rem <= 0 {
+		return 0, nil
+	}
+	if len(b) > rem {
+		p.size += rem
+		return p.buffer.Write(b[:rem])
+	}
+	p.size += len(b)
+	return p.buffer.Write(b)
 }

--- a/variables.go
+++ b/variables.go
@@ -178,7 +178,7 @@ type mapVars struct {
 func (v *mapVars) Variables(a *Adapter) []*dap.Variable {
 	keys := v.MapKeys()
 	vars := make([]*dap.Variable, len(keys))
-	vp := newValuePrinter(16)
+	vp := newValuePrinter(64)
 	for i, k := range keys {
 		vars[i] = a.newVar(vp.printString(k), v.MapIndex(k))
 	}

--- a/variables.go
+++ b/variables.go
@@ -1,6 +1,7 @@
 package dbg
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 	"sync"
@@ -94,8 +95,18 @@ func (a *Adapter) newVar(name string, rv reflect.Value) *dap.Variable {
 	switch rv.Kind() {
 	case rChan, rFunc, rInterface, rMap, rPtr, rSlice, rArray, rStruct:
 		v.Value = rv.Type().String()
+	case rInt, rInt8, rInt16, rInt32, rInt64:
+		v.Value = strconv.FormatInt(rv.Int(), 10)
+	case rUint8, rUint16, rUint, rUint32, rUint64, rUintptr:
+		v.Value = fmt.Sprintf("%v", rv)
+	case rBool:
+		v.Value = strconv.FormatBool(rv.Bool())
+	case rFloat32, rFloat64, rComplex128, rComplex64:
+		v.Value = fmt.Sprintf("%v", rv)
+	case rString:
+		v.Value = fmt.Sprintf("%q", rv.String())
 	default:
-		v.Value = rv.String()
+		v.Value = fmt.Sprintf("%[1]v (%[1]T)", rv)
 	}
 
 	switch rv.Kind() {

--- a/variables.go
+++ b/variables.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/traefik-contrib/yaegi-debug-adapter/pkg/dap"
 	"github.com/traefik/yaegi/interp"
@@ -207,7 +208,20 @@ func (p *valuePrinter) printString(rv reflect.Value) string {
 
 func (p *valuePrinter) print(rv reflect.Value) {
 	switch rv.Kind() {
-	case rChan, rFunc, rInterface, rPtr, rStruct:
+	case rStruct:
+		if rv.Type() == reflect.TypeOf(time.Time{}) {
+			t := rv.Interface().(time.Time)
+			fmt.Fprint(p, t.String())
+			return
+		}
+		fmt.Fprint(p, rv.Type().String())
+	case rPtr:
+		if rv.IsNil() {
+			fmt.Fprint(p, "nil")
+		}
+		fmt.Fprintf(p, "*")
+		p.print(rv.Elem())
+	case rChan, rFunc, rInterface:
 		fmt.Fprint(p, rv.Type().String())
 	case rInt, rInt8, rInt16, rInt32, rInt64:
 		fmt.Fprint(p, strconv.FormatInt(rv.Int(), 10))

--- a/variables_test.go
+++ b/variables_test.go
@@ -33,11 +33,13 @@ func TestNewVar_Value(t *testing.T) {
 		{"string", reflect.ValueOf("shoe"), `"shoe"`},
 		{"float32", reflect.ValueOf(float32(3.14159)), "3.14159"},
 		{"float64", reflect.ValueOf(float64(3.14159)), "3.14159"},
-		{"[]int", reflect.ValueOf([]int{21}), "[]int{21}"},
-		{"[]int", reflect.ValueOf([]int{21}), "[]int{21}"},
+		{"[]int", reflect.ValueOf([]int{}), "[]int{}"},
+		{"[]int{21}", reflect.ValueOf([]int{21}), "[]int{21}"},
+		{"[2]bool{false, true}", reflect.ValueOf([2]bool{false, true}), "[2]bool{false,true}"},
 		{"func", reflect.ValueOf(a.newVar), "func(string, reflect.Value) *dap.Variable"},
 		{"struct", reflect.ValueOf(a), "*dbg.Adapter"},
-		{"map", reflect.ValueOf(map[bool]bool{}), "map[bool]bool"},
+		{"map", reflect.ValueOf(map[bool]bool{}), "map[bool]bool{}"},
+		{"map[int]int{-1:2,3:-4}", reflect.ValueOf(map[int]int{-1: 2, 3: -4}), "map[int]int{-1:2,3:-4}"},
 		{"unsafe", reflect.ValueOf(u), fmt.Sprintf("reflect.Value %v", u)},
 	}
 	for _, each := range cases {
@@ -57,7 +59,7 @@ func TestValuePrinterSmallMaxLength(t *testing.T) {
 		out   string
 	}{
 		{"string", reflect.ValueOf("some long text that is cut"), `"some lo...`},
-		{"a := []int{12345678}", reflect.ValueOf([]int{12345678, 23456789}), "[]int{12..."},
+		{"[]int{12345678}", reflect.ValueOf([]int{12345678, 23456789}), "[]int{12..."},
 	}
 	for _, each := range cases {
 		t.Run(each.name, func(t *testing.T) {

--- a/variables_test.go
+++ b/variables_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 	"unsafe"
 )
 
@@ -11,6 +12,9 @@ func TestNewVar_Value(t *testing.T) {
 	a := &Adapter{vars: newVariables()}
 	var b chan bool
 	u := unsafe.Pointer(a)
+	now := time.Now()
+	var then *time.Time
+	i := 42
 
 	cases := []struct {
 		name  string
@@ -20,6 +24,7 @@ func TestNewVar_Value(t *testing.T) {
 		{"nil chan", reflect.ValueOf(b), "nil"},
 		{"int", reflect.ValueOf(int(-42)), "-42"},
 		{"int8", reflect.ValueOf(int8(-42)), "-42"},
+		{"*int", reflect.ValueOf(&i), "*42"},
 		{"int16", reflect.ValueOf(int16(-42)), "-42"},
 		{"int32", reflect.ValueOf(int32(-42)), "-42"},
 		{"int64", reflect.ValueOf(int64(12345)), "12345"},
@@ -41,6 +46,9 @@ func TestNewVar_Value(t *testing.T) {
 		{"map", reflect.ValueOf(map[bool]bool{}), "map[bool]bool{}"},
 		{"map[int]int{-1:2}", reflect.ValueOf(map[int]int{-1: 2}), "map[int]int{-1:2}"},
 		{"unsafe", reflect.ValueOf(u), fmt.Sprintf("reflect.Value %v", u)},
+		{"time", reflect.ValueOf(now), fmt.Sprintf("%v", now)},
+		{"*time", reflect.ValueOf(&now), fmt.Sprintf("*%v", now)},
+		{"nil *time", reflect.ValueOf(then), "nil"},
 	}
 	for _, each := range cases {
 		t.Run(each.name, func(t *testing.T) {

--- a/variables_test.go
+++ b/variables_test.go
@@ -1,0 +1,50 @@
+package dbg
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+func TestNewVar(t *testing.T) {
+	a := &Adapter{vars: newVariables()}
+	var b chan bool
+	u := unsafe.Pointer(a)
+
+	cases := []struct {
+		name  string
+		value reflect.Value
+		out   string
+	}{
+		{"nil chan", reflect.ValueOf(b), "nil"},
+		{"int", reflect.ValueOf(int(-42)), "-42"},
+		{"int8", reflect.ValueOf(int8(-42)), "-42"},
+		{"int16", reflect.ValueOf(int16(-42)), "-42"},
+		{"int32", reflect.ValueOf(int32(-42)), "-42"},
+		{"int64", reflect.ValueOf(int64(12345)), "12345"},
+		{"uintptr", reflect.ValueOf(uintptr(2)), "2"},
+		{"bool", reflect.ValueOf(true), "true"},
+		{"uint", reflect.ValueOf(1), "1"},
+		{"uint8", reflect.ValueOf(uint8(1)), "1"},
+		{"uint16", reflect.ValueOf(uint16(1)), "1"},
+		{"uint32", reflect.ValueOf(uint32(1)), "1"},
+		{"uint64", reflect.ValueOf(uint64(1)), "1"},
+		{"string", reflect.ValueOf("shoe"), `"shoe"`},
+		{"float32", reflect.ValueOf(float32(3.14159)), "3.14159"},
+		{"float64", reflect.ValueOf(float64(3.14159)), "3.14159"},
+		{"[]int", reflect.ValueOf([]int{21}), "[]int"},
+		{"func", reflect.ValueOf(a.newVar), "func(string, reflect.Value) *dap.Variable"},
+		{"struct", reflect.ValueOf(a), "*dbg.Adapter"},
+		{"map", reflect.ValueOf(map[bool]bool{}), "map[bool]bool"},
+		{"unsafe", reflect.ValueOf(u), fmt.Sprintf("%v (reflect.Value)", u)},
+	}
+	for _, each := range cases {
+		t.Run(each.name, func(t *testing.T) {
+			dapVar := a.newVar(each.name, each.value)
+			if got, want := dapVar.Value, each.out; got != want {
+				t.Errorf("got [%[1]v:%[1]T] want [%[2]v:%[2]T]", got, want)
+			}
+		})
+	}
+}

--- a/variables_test.go
+++ b/variables_test.go
@@ -34,12 +34,12 @@ func TestNewVar_Value(t *testing.T) {
 		{"float32", reflect.ValueOf(float32(3.14159)), "3.14159"},
 		{"float64", reflect.ValueOf(float64(3.14159)), "3.14159"},
 		{"[]int", reflect.ValueOf([]int{}), "[]int{}"},
-		{"[]int{21}", reflect.ValueOf([]int{21}), "[]int{21}"},
+		{"[]int{21,42}", reflect.ValueOf([]int{21, 42}), "[]int{21,42}"},
 		{"[2]bool{false, true}", reflect.ValueOf([2]bool{false, true}), "[2]bool{false,true}"},
 		{"func", reflect.ValueOf(a.newVar), "func(string, reflect.Value) *dap.Variable"},
 		{"struct", reflect.ValueOf(a), "*dbg.Adapter"},
 		{"map", reflect.ValueOf(map[bool]bool{}), "map[bool]bool{}"},
-		{"map[int]int{-1:2,3:-4}", reflect.ValueOf(map[int]int{-1: 2, 3: -4}), "map[int]int{-1:2,3:-4}"},
+		{"map[int]int{-1:2}", reflect.ValueOf(map[int]int{-1: 2}), "map[int]int{-1:2}"},
 		{"unsafe", reflect.ValueOf(u), fmt.Sprintf("reflect.Value %v", u)},
 	}
 	for _, each := range cases {
@@ -69,5 +69,17 @@ func TestValuePrinterSmallMaxLength(t *testing.T) {
 				t.Errorf("got [%[1]v:%[1]T] want [%[2]v:%[2]T]", got, want)
 			}
 		})
+	}
+}
+
+func TestValuePrinterPrintString(t *testing.T) {
+	vp := newValuePrinter(7)
+	rv := reflect.ValueOf("yaegi")
+	if got, want := vp.printString(rv), `"yaegi"`; got != want {
+		t.Errorf("got [%[1]v:%[1]T] want [%[2]v:%[2]T]", got, want)
+	}
+	// buffer is reset
+	if got, want := vp.printString(rv), `"yaegi"`; got != want {
+		t.Errorf("got [%[1]v:%[1]T] want [%[2]v:%[2]T]", got, want)
 	}
 }


### PR DESCRIPTION
This PR changes the computation of the Value of a debug Variable by adding more switch cases and using a printer with a bounded buffer to prevent large string values when displaying large structures.

Fixes #6